### PR TITLE
Fix failure when installing homebrew cask

### DIFF
--- a/homebrew-casks/verify-install.sh
+++ b/homebrew-casks/verify-install.sh
@@ -1,1 +1,1 @@
-brew tap | grep -q "caskroom/cask"
+brew tap | grep -q "cask"


### PR DESCRIPTION
On a fresh workstation `brew tap` was returning `homebrew/cask` while the verify script was expecting `caskroom/cask`. Didn't dig into the reason for the change :shrug: